### PR TITLE
Fixed missing open squiggly bracket after the translation from Coffeescript to ES6

### DIFF
--- a/modules/Task/Task.js
+++ b/modules/Task/Task.js
@@ -103,7 +103,7 @@ module.controller( 'TaskForm', ($scope, task) => {
 module.factory( 'Task', (BaseObject, $http) => {
   class Task extends BaseObject {
     create() {
-      return $http.post('/api/tasks', this).then( (response) =>
+      return $http.post('/api/tasks', this).then( (response) => {
         this.id = response.data.id;
         return response.data;
       });


### PR DESCRIPTION
Babel complains when trying to compile due to a missing squiggly bracket.  This ORM is amazing by the way.